### PR TITLE
update: Show notification on a badly rated site

### DIFF
--- a/checker.js
+++ b/checker.js
@@ -25,6 +25,7 @@ function notify(title, body) {
   });
 
   notification.onclick = function() {
+    safari.application.activeBrowserWindow.openTab().url = 'http://tosdr.org/#' + title;
     this.close();
   }
 }

--- a/checker.js
+++ b/checker.js
@@ -17,6 +17,23 @@ function getTosButton (tab) {
   }
 }
 
+function notify(title, body) {
+  var notification = new Notification(title, {
+    'body': body,
+    // prevent duplicate notifications
+    'tag' : 'tosdr-' + title
+  });
+
+  notification.onclick = function() {
+    this.close();
+  }
+}
+
+RATING_TEXT = {
+    "D": "The terms of service are very uneven or there are some important issues that need your attention.",
+    "E": "The terms of service raise very serious concerns."
+};
+
 function onNewUrl (event) {
   var service = Tosdr.getService(event.target.url);
   var button = getTosButton(event.target);
@@ -25,6 +42,10 @@ function onNewUrl (event) {
   if (service) {
     if (service.tosdr.rated) {
       button.image = safari.extension.baseURI + 'icons/' + service.tosdr.rated.toLowerCase() + '.png';
+      // show notification in case of bad rating
+      if (service.tosdr.rated == 'D' || service.tosdr.rated == 'E') {
+          notify(service.name, RATING_TEXT[service.tosdr.rated]);
+      }
     }
     else {
       button.image = safari.extension.baseURI + 'icons/false.png';


### PR DESCRIPTION
- Mimic notifications on Firefox and Chrome tos;dr extensions

Signed-off-by: mr.Shu mr@shu.io

----8<----

Couple of questions:
- right now shows notifications every time the user load a bad rated URL. Should we show this just once per browser session?
- on Firefox clicking on a notification will open the tosdr.org site with the service's rating. Should we do the same here?
